### PR TITLE
Set width of images explicitly so they don't appear as large.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ It was helpful to me, and I hope it can be helpful to you.
 
 It can be invoked with arguments directly:
 
-* `=RSUDIST(16, "1/1/2020")`
+`=RSUDIST(16, "1/1/2020")`
 
-![RSUDIST with values](images/rsudist-invocation-by-value.jpg)
+<img alt="RSUDIST with values" src="images/rsudist-invocation-by-value.jpg" width="250" />
 
 Alternatively, you could put `16` in a cell side-by-side `1/1/2020`
 and you can pass in references to those cells:
 
-* `=RSUDIST(A1:B1)`
+`=RSUDIST(A1:B1)`
 
-![RSUDIST with references](images/rsudist-invocation-by-reference.jpg)
+<img alt="RSUDIST with references" src="images/rsudist-invocation-by-reference.jpg" width="400" />
 
 If you're in the fortunate situation where you have two grants, you
 could put a grant in each row (like above) and then pass in references
@@ -63,9 +63,9 @@ to those two rows. In this situation, `=RSUDIST` will merge the
 results, and if vest dates overlap the RSUs vested will be added
 together:
 
-* `=RSUDIST(A1:B2)`
+`=RSUDIST(A1:B2)`
 
-![RSUDIST with two grants](images/rsudist-two-grants.jpg)
+<img alt="RSUDIST with two grants" src="images/rsudist-two-grants.jpg" width="400" />
 
 ## Assumptions and a Warning
 


### PR DESCRIPTION
The inline image approach with images sets a `style="width:100%"` on the rendered result, and that's too large.

This change replaces markdown with more explicit HTML so the end result is that the images are displayed at a more manageable size.